### PR TITLE
use https package_index.json urls for most boards

### DIFF
--- a/.github/workflows/arduino-test-compile-Test.yml
+++ b/.github/workflows/arduino-test-compile-Test.yml
@@ -69,7 +69,7 @@ jobs:
                 -DTRACE
 
 #         - arduino-boards-fqbn: digistump:avr:digispark-tiny1  # ATtiny85 board @1 MHz
-#            platform-url: http://digistump.com/package_digistump_index.json
+#            platform-url: https://digistump.com/package_digistump_index.json
 #            # examples-build-properties / aka setting compiler.cpp.extra_flags does not work for digistump:avr platform
 #            examples-exclude: WhistleSwitch "Test" # Space separated list of (unique substrings of) example names to exclude in build
 
@@ -80,7 +80,7 @@ jobs:
 #                -DFREQUENCY_RANGE_LOW
 
           - arduino-boards-fqbn: esp8266:esp8266:huzzah:eesz=4M3M,xtal=80
-            platform-url: http://arduino.esp8266.com/stable/package_esp8266com_index.json
+            platform-url: https://arduino.esp8266.com/stable/package_esp8266com_index.json
             examples-exclude: WhistleSwitch 50Hz SimpleFrequencyDetector
 
           - arduino-boards-fqbn: esp32:esp32:featheresp32:FlashFreq=80

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ arduino-board-fqbn: esp8266:esp8266:huzzah:eesz=4M3M,xtal=80
 Required for 3rd party boards.
 
 ```yaml
-platform-url: http://arduino.esp8266.com/stable/package_esp8266com_index.json
+platform-url: https://arduino.esp8266.com/stable/package_esp8266com_index.json
 ```
 
 Sample URL's are:
 - http://drazzy.com/package_drazzy.com_index.json - for ATTiny boards
-- http://digistump.com/package_digistump_index.json - for Digispark boards
-- http://arduino.esp8266.com/stable/package_esp8266com_index.json - for ESP8266 based boards
+- https://digistump.com/package_digistump_index.json - for Digispark boards
+- https://arduino.esp8266.com/stable/package_esp8266com_index.json - for ESP8266 based boards
 - https://dl.espressif.com/dl/package_esp32_index.json - for ESP32 based boards
 - https://github.com/stm32duino/BoardManagerFiles/raw/dev/STM32/package_stm_index.json - for STM32 boards
 - https://raw.githubusercontent.com/sparkfun/Arduino_Boards/master/IDE_Board_Manager/package_sparkfun_index.json - for Sparkfun boards, esp. Apollo3 boards
@@ -114,7 +114,7 @@ jobs:
       uses: actions/arduino-test-compile@master
       with:
         arduino-board-fqbn: esp8266:esp8266:huzzah:eesz=4M3M,xtal=80
-        platform-url: http://arduino.esp8266.com/stable/package_esp8266com_index.json
+        platform-url: https://arduino.esp8266.com/stable/package_esp8266com_index.json
         libraries: Servo "Adafruit NeoPixel"
         examples-exclude: WhistleSwitch 50Hz
 ```
@@ -154,7 +154,7 @@ jobs:
                 -DTRACE
 
           - arduino-boards-fqbn: esp8266:esp8266:huzzah:eesz=4M3M,xtal=80
-            platform-url: http://arduino.esp8266.com/stable/package_esp8266com_index.json
+            platform-url: https://arduino.esp8266.com/stable/package_esp8266com_index.json
             examples-exclude: WhistleSwitch 50Hz SimpleFrequencyDetector          
 
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -173,7 +173,8 @@ jobs:
           examples-build-properties: ${{ toJson(matrix.examples-build-properties) }}
 ```
 Other samples:
-- One sketch, one board, multiple options. RobotCar [![Build Status](https://github.com/ArminJo/Arduino-RobotCar/workflows/TestCompile/badge.svg)](https://github.com/ArminJo/Arduino-RobotCar/blob/master/.github/workflows/LibraryBuild.yml)
+- One sketch, one library. Simple-DSO [![Build Status](https://github.com/ArminJo/Arduino-Simple-DSO/workflows/TestCompile/badge.svg)](https://github.com/ArminJo/Arduino-Simple-DSO/blob/master/.github/workflows/TestCompile.yml)
+- One sketch, one board, multiple options. RobotCar [![Build Status](https://github.com/ArminJo/Arduino-RobotCar/workflows/TestCompile/badge.svg)](https://github.com/ArminJo/Arduino-RobotCar/blob/master/.github/workflows/TestCompile.yml)
 - Arduino library, 2 boards. Arduino-FrequencyDetector [![Build Status](https://github.com/ArminJo/Arduino-FrequencyDetector/workflows/LibraryBuild/badge.svg)](https://github.com/ArminJo/Arduino-FrequencyDetector/blob/master/.github/workflows/LibraryBuildWithAction.yml)
 - Arduino library, multiple boards. ServoEasing [![Build Status](https://github.com/ArminJo/ServoEasing/workflows/LibraryBuild/badge.svg)](https://github.com/ArminJo/ServoEasing/blob/master/.github/workflows/LibraryBuild.yml)
 
@@ -184,4 +185,4 @@ Other samples:
 ## Requests for modifications / extensions
 Please write me a PM including your motivation/problem if you need a modification or an extension.
 
-#### If you find this library useful, please give it a star.
+#### If you find this action useful, please give it a star.


### PR DESCRIPTION
Updated example urls.
http://drazzy.com/package_drazzy.com_index.json does not support https SpenceKonde/ATTinyCore#394