### PR TITLE
Apply example-build-properties to .c and .S files too

### DIFF
--- a/arduino-test-compile.sh
+++ b/arduino-test-compile.sh
@@ -271,27 +271,27 @@ for sketch_name in "${SKETCH_NAMES_ARRAY[@]}"; do # Loop over all sketch names
         cp -R ${SKETCH_PATH}/* $HOME/$SKETCH_BASENAME
         SKETCH_PATH=$HOME/$SKETCH_BASENAME
       fi
-      # check if there is an entry in the associative array and create compile parameter to put in compiler.cpp.extra_flags
+      # check if there is an entry in the associative array and create compile parameter to put in compiler.*.extra_flags
       echo -n "Compiling $SKETCH_BASENAME "
       if [[ -n ${PROP_MAP[$SKETCH_BASENAME]} ]]; then
-        CPP_EXTRA_FLAGS=${PROP_MAP[$SKETCH_BASENAME]}
-        echo -n "with $CPP_EXTRA_FLAGS "
+        GCC_EXTRA_FLAGS=${PROP_MAP[$SKETCH_BASENAME]}
+        echo -n "with $GCC_EXTRA_FLAGS "
       elif [[ -n ${PROP_MAP[All]} ]]; then
-        CPP_EXTRA_FLAGS=${PROP_MAP[All]}
-        echo -n "with $CPP_EXTRA_FLAGS "
+        GCC_EXTRA_FLAGS=${PROP_MAP[All]}
+        echo -n "with $GCC_EXTRA_FLAGS "
       else
-        CPP_EXTRA_FLAGS=
+        GCC_EXTRA_FLAGS=
       fi
-        build_stdout=$(arduino-cli compile --verbose --warnings all --fqbn ${ARDUINO_BOARD_FQBN%|*} --build-properties compiler.cpp.extra_flags="${CPP_EXTRA_FLAGS}" $SKETCH_PATH 2>&1)
+        build_stdout=$(arduino-cli compile --verbose --warnings all --fqbn ${ARDUINO_BOARD_FQBN%|*} --build-properties compiler.cpp.extra_flags="${GCC_EXTRA_FLAGS}" --build-properties compiler.c.extra_flags="${GCC_EXTRA_FLAGS}" --build-properties compiler.S.extra_flags="${GCC_EXTRA_FLAGS}" $SKETCH_PATH 2>&1)
       if [[ $? -ne 0 ]]; then
         echo -e ""$RED"\xe2\x9c\x96" # If ok output a green checkmark else a red X and the command output.
-        echo "arduino-cli compile --verbose --warnings all --fqbn ${ARDUINO_BOARD_FQBN%|*} --build-properties compiler.cpp.extra_flags=\"${CPP_EXTRA_FLAGS}\" $SKETCH_PATH"
+        echo "arduino-cli compile --verbose --warnings all --fqbn ${ARDUINO_BOARD_FQBN%|*} --build-properties compiler.cpp.extra_flags=\"${GCC_EXTRA_FLAGS}\" --build-properties compiler.c.extra_flags=\"${GCC_EXTRA_FLAGS}\" --build-properties compiler.S.extra_flags=\"${GCC_EXTRA_FLAGS}\" $SKETCH_PATH"
         echo "::error::Compile of  $SKETCH_BASENAME ${CPP_EXTRA_FLAGS} failed"
         echo -e "$build_stdout \n"
         exit_code=1
       else
         echo -e ""$GREEN"\xe2\x9c\x93"
-        echo "arduino-cli compile --verbose --warnings all --fqbn ${ARDUINO_BOARD_FQBN%|*} --build-properties compiler.cpp.extra_flags=\"${CPP_EXTRA_FLAGS}\" $SKETCH_PATH"
+        echo "arduino-cli compile --verbose --warnings all --fqbn ${ARDUINO_BOARD_FQBN%|*} --build-properties compiler.cpp.extra_flags=\"${GCC_EXTRA_FLAGS}\" --build-properties compiler.c.extra_flags=\"${GCC_EXTRA_FLAGS}\" --build-properties compiler.S.extra_flags=\"${GCC_EXTRA_FLAGS}\" $SKETCH_PATH"
         if [[ $DEBUG_COMPILE == true ]]; then
           echo "Debug mode enabled => compile output will be printed also for successful compilation and sketch directory is listed after compilation"
           echo -e "$build_stdout \n"


### PR DESCRIPTION
I noticed that example-build-properties were only added to `compiler.cpp.extra_flags`, so only applied to C++ files. There are also recipes for .c and .S files, which were not compiled with these extra build flags. I suspect this is not intentional, and in my case it was problematic.

This PR applies the same extra flags to .c and .S files. I've tested this for .c files, I expect this to work for .S files just as well.