### PR TITLE
Fail if no sketches were found to compile

### DIFF
--- a/arduino-test-compile.sh
+++ b/arduino-test-compile.sh
@@ -245,6 +245,7 @@ if [[ $DEBUG_COMPILE == true ]]; then
   declare -p SKETCH_NAMES_ARRAY
 fi
 IFS="$BACKUP_IFS"
+COMPILED_SKETCHES=
 for sketch_name in "${SKETCH_NAMES_ARRAY[@]}"; do # Loop over all sketch names
   declare -a SKETCHES=($(find ${SKETCH_NAMES_FIND_START} -type f -name "$sketch_name")) # only search for files
   if [[ $DEBUG_COMPILE == true ]]; then
@@ -299,7 +300,12 @@ for sketch_name in "${SKETCH_NAMES_ARRAY[@]}"; do # Loop over all sketch names
           ls -l $SKETCH_PATH
         fi
       fi
+      COMPILED_SKETCHES="$COMPILED_SKETCHES $SKETCH_NAME"
     fi
   done
 done
+if [ -z "$COMPILED_SKETCHES" ]; then
+  echo "Did not find any sketches to compile, probably misconfigured?"
+  exit_code=1
+fi
 exit $exit_code


### PR DESCRIPTION
This catches accidental misconfiguration, or changes that somehow cause
no sketches to be compiled.