### PR TITLE
Configure Arduino CLI to export binaries to the sketch folder

### DIFF
--- a/arduino-test-compile.sh
+++ b/arduino-test-compile.sh
@@ -265,6 +265,8 @@ else
   fi
 fi
 
+# Save generated files to the build subfolder of the sketch
+export ARDUINO_SKETCH_ALWAYS_EXPORT_BINARIES=true
 
 #
 # Get the build property map


### PR DESCRIPTION
As is documented in this project's readme, Arduino CLI 0.11.0 - 0.13.0 saves the compiled binaries to the `build` subfolder of the sketch by default. This behavior will change in the next Arduino CLI release (see: https://github.com/arduino/arduino-cli/issues/1051) to defaulting to not save the binaries.

The previous behavior may be most easily preserved in a backwards compatible manner by configuring Arduino CLI's `sketch.always_export_binaries` configuration setting via an environment variable:
https://arduino.github.io/arduino-cli/latest/configuration/#environment-variables

Even though the change to Arduino CLI won't affect this project until the next release of Arduino CLI, I thought it best to prepare in advance to make it possible to avoid any disruption to users whose workflows might rely on the availability of the binaries.