### PR TITLE
Bug Fix in arduino-test-compile.sh

### DIFF
--- a/arduino-test-compile.sh
+++ b/arduino-test-compile.sh
@@ -343,7 +343,7 @@ for sketch_name in "${SKETCH_NAMES_ARRAY[@]}"; do # Loop over all sketch names
     SKETCH_DIR=${SKETCH_PATH##*/}  # directory of sketch, must match sketch basename
     SKETCH_FILENAME=$(basename $sketch) # complete name of sketch
     SKETCH_EXTENSION=${SKETCH_FILENAME##*.} # extension of sketch
-    SKETCH_BASENAME=${SKETCH_FILENAME%%.*} # name without extension / basename of sketch, must match directory name
+    SKETCH_BASENAME=${SKETCH_FILENAME%%.$SKETCH_EXTENSION} # name without extension / basename of sketch, must match directory name
     echo -e "\n"
     if [[ $SKETCHES_EXCLUDE == *"$SKETCH_BASENAME"* ]]; then
       echo -e "Skipping $SKETCH_PATH \xe2\x9e\x9e" # Right arrow


### PR DESCRIPTION
Hi

I have made a little modification on **SKETCH_BASENAME** determination

My sketch have this name **CtlTemp-V4.2.0.ino**. For this reason the line

`SKETCH_EXTENSION=${SKETCH_FILENAME##*.} # extension of sketch`

is correct = .ino
But this line

`SKETCH_BASENAME=${SKETCH_FILENAME%%.*} # name without extension / basename of sketch, must match directory name`

Create **CtlTemp-V4**

So I have changed it in a more friendly

`SKETCH_BASENAME=${SKETCH_FILENAME%%.$SKETCH_EXTENSION} # name without extension / basename of sketch, must match directory name`

So now the **SKETCH_BASENAME** is **CtlTemp-V4.2.0**

ciao
matteo
